### PR TITLE
Update for dynamic schema

### DIFF
--- a/mappers/audit_log_mapper.go
+++ b/mappers/audit_log_mapper.go
@@ -10,14 +10,9 @@ import (
 
 	"github.com/turbot/pipe-fittings/utils"
 	"github.com/turbot/tailpipe-plugin-gcp/rows"
-	"github.com/turbot/tailpipe-plugin-sdk/table"
 )
 
 type AuditLogMapper struct {
-}
-
-func NewAuditLogMapper() table.Mapper[*rows.AuditLog] {
-	return &AuditLogMapper{}
 }
 
 func (m *AuditLogMapper) Identifier() string {

--- a/sources/audit_log_api_source.go
+++ b/sources/audit_log_api_source.go
@@ -64,10 +64,12 @@ func (s *AuditLogAPISource) Collect(ctx context.Context) error {
 	}
 
 	sourceName := AuditLogAPISourceIdentifier
-	sourceEnrichmentFields := &enrichment.CommonFields{
-		TpSourceName:     &sourceName,
-		TpSourceType:     AuditLogAPISourceIdentifier,
-		TpSourceLocation: &project,
+	sourceEnrichmentFields := &enrichment.SourceEnrichment{
+		CommonFields: enrichment.CommonFields{
+			TpSourceName:     &sourceName,
+			TpSourceType:     AuditLogAPISourceIdentifier,
+			TpSourceLocation: &project,
+		},
 	}
 
 	filter := s.getLogNameFilter(project, *startTime)
@@ -86,8 +88,8 @@ func (s *AuditLogAPISource) Collect(ctx context.Context) error {
 		if logEntry != nil {
 			if collectionState.ShouldCollectRow(logEntry.Timestamp, logEntry.InsertID) {
 				row := &types.RowData{
-					Data:     *logEntry,
-					Metadata: sourceEnrichmentFields,
+					Data:             *logEntry,
+					SourceEnrichment: sourceEnrichmentFields,
 				}
 
 				// update collection state

--- a/sources/storage_bucket_source.go
+++ b/sources/storage_bucket_source.go
@@ -81,13 +81,15 @@ func (s *GcpStorageBucketSource) DiscoverArtifacts(ctx context.Context) error {
 		}
 		objPath := obj.Name
 		if s.Extensions.IsValid(objPath) {
-			sourceEnrichmentFields := &enrichment.CommonFields{
-				TpSourceLocation: &objPath,
-				TpSourceName:     &s.Config.Bucket,
-				TpSourceType:     GcpStorageBucketSourceIdentifier,
+			sourceEnrichmentFields := &enrichment.SourceEnrichment{
+				CommonFields: enrichment.CommonFields{
+					TpSourceLocation: &objPath,
+					TpSourceName:     &s.Config.Bucket,
+					TpSourceType:     GcpStorageBucketSourceIdentifier,
+				},
 			}
 
-			info := &types.ArtifactInfo{Name: objPath, OriginalName: objPath, EnrichmentFields: sourceEnrichmentFields}
+			info := &types.ArtifactInfo{Name: objPath, OriginalName: objPath, SourceEnrichment: sourceEnrichmentFields}
 
 			if err := s.OnArtifactDiscovered(ctx, info); err != nil {
 				// TODO: #error should we continue or fail?
@@ -123,7 +125,7 @@ func (s *GcpStorageBucketSource) DownloadArtifact(ctx context.Context, info *typ
 		return fmt.Errorf("failed to write data to file, %w", err)
 	}
 
-	downloadInfo := &types.ArtifactInfo{Name: localFilePath, OriginalName: info.Name, EnrichmentFields: info.EnrichmentFields}
+	downloadInfo := &types.ArtifactInfo{Name: localFilePath, OriginalName: info.Name, SourceEnrichment: info.SourceEnrichment}
 
 	// TODO: #delta create collection state data https://github.com/turbot/tailpipe-plugin-sdk/issues/13
 	return s.OnArtifactDownloaded(ctx, downloadInfo)

--- a/tables/audit_log_admin_activity_table.go
+++ b/tables/audit_log_admin_activity_table.go
@@ -26,11 +26,11 @@ func (c *AuditLogAdminActivityTable) Identifier() string {
 	return AuditLogAdminActivityTableIdentifier
 }
 
-func (c *AuditLogAdminActivityTable) SupportedSources(_ *AuditLogAdminActivityTableConfig) []*table.SourceMetadata[*rows.AuditLog] {
+func (c *AuditLogAdminActivityTable) GetSourceMetadata(_ *AuditLogAdminActivityTableConfig) []*table.SourceMetadata[*rows.AuditLog] {
 	return []*table.SourceMetadata[*rows.AuditLog]{
 		{
 			SourceName: sources.AuditLogAPISourceIdentifier,
-			MapperFunc: mappers.NewAuditLogMapper,
+			Mapper:     &mappers.AuditLogMapper{},
 			Options: []row_source.RowSourceOption{
 				sources.WithLogType(string(AuditLogTypeActivity)),
 			},
@@ -38,6 +38,6 @@ func (c *AuditLogAdminActivityTable) SupportedSources(_ *AuditLogAdminActivityTa
 	}
 }
 
-func (c *AuditLogAdminActivityTable) EnrichRow(row *rows.AuditLog, sourceEnrichmentFields *enrichment.CommonFields) (*rows.AuditLog, error) {
+func (c *AuditLogAdminActivityTable) EnrichRow(row *rows.AuditLog, _ *AuditLogAdminActivityTableConfig, sourceEnrichmentFields enrichment.SourceEnrichment) (*rows.AuditLog, error) {
 	return EnrichAuditLogRow(row, sourceEnrichmentFields)
 }

--- a/tables/audit_log_data_access_table.go
+++ b/tables/audit_log_data_access_table.go
@@ -26,11 +26,11 @@ func (c *AuditLogDataAccessTable) Identifier() string {
 	return AuditLogDataAccessTableIdentifier
 }
 
-func (c *AuditLogDataAccessTable) SupportedSources(_ *AuditLogDataAccessTableConfig) []*table.SourceMetadata[*rows.AuditLog] {
+func (c *AuditLogDataAccessTable) GetSourceMetadata(_ *AuditLogDataAccessTableConfig) []*table.SourceMetadata[*rows.AuditLog] {
 	return []*table.SourceMetadata[*rows.AuditLog]{
 		{
 			SourceName: sources.AuditLogAPISourceIdentifier,
-			MapperFunc: mappers.NewAuditLogMapper,
+			Mapper:     &mappers.AuditLogMapper{},
 			Options: []row_source.RowSourceOption{
 				sources.WithLogType(string(AuditLogTypeDataAccess)),
 			},
@@ -38,6 +38,6 @@ func (c *AuditLogDataAccessTable) SupportedSources(_ *AuditLogDataAccessTableCon
 	}
 }
 
-func (c *AuditLogDataAccessTable) EnrichRow(row *rows.AuditLog, sourceEnrichmentFields *enrichment.CommonFields) (*rows.AuditLog, error) {
+func (c *AuditLogDataAccessTable) EnrichRow(row *rows.AuditLog, _ *AuditLogDataAccessTableConfig, sourceEnrichmentFields enrichment.SourceEnrichment) (*rows.AuditLog, error) {
 	return EnrichAuditLogRow(row, sourceEnrichmentFields)
 }

--- a/tables/audit_log_system_event_table.go
+++ b/tables/audit_log_system_event_table.go
@@ -26,11 +26,11 @@ func (c *AuditLogSystemEventTable) Identifier() string {
 	return AuditLogSystemEventTableIdentifier
 }
 
-func (c *AuditLogSystemEventTable) SupportedSources(_ *AuditLogSystemEventTableConfig) []*table.SourceMetadata[*rows.AuditLog] {
+func (c *AuditLogSystemEventTable) GetSourceMetadata(_ *AuditLogSystemEventTableConfig) []*table.SourceMetadata[*rows.AuditLog] {
 	return []*table.SourceMetadata[*rows.AuditLog]{
 		{
 			SourceName: sources.AuditLogAPISourceIdentifier,
-			MapperFunc: mappers.NewAuditLogMapper,
+			Mapper:     &mappers.AuditLogMapper{},
 			Options: []row_source.RowSourceOption{
 				sources.WithLogType(string(AuditLogTypeSystemEvent)),
 			},
@@ -38,6 +38,6 @@ func (c *AuditLogSystemEventTable) SupportedSources(_ *AuditLogSystemEventTableC
 	}
 }
 
-func (c *AuditLogSystemEventTable) EnrichRow(row *rows.AuditLog, sourceEnrichmentFields *enrichment.CommonFields) (*rows.AuditLog, error) {
+func (c *AuditLogSystemEventTable) EnrichRow(row *rows.AuditLog, _ *AuditLogSystemEventTableConfig, sourceEnrichmentFields enrichment.SourceEnrichment) (*rows.AuditLog, error) {
 	return EnrichAuditLogRow(row, sourceEnrichmentFields)
 }

--- a/tables/shared.go
+++ b/tables/shared.go
@@ -17,12 +17,8 @@ const (
 	AuditLogTypeDataAccess  AuditLogType = "data_access"
 )
 
-func EnrichAuditLogRow(row *rows.AuditLog, sourceEnrichmentFields *enrichment.CommonFields) (*rows.AuditLog, error) {
-
-	if sourceEnrichmentFields != nil {
-		row.CommonFields = *sourceEnrichmentFields
-	}
-
+func EnrichAuditLogRow(row *rows.AuditLog, sourceEnrichmentFields enrichment.SourceEnrichment) (*rows.AuditLog, error) {
+	row.CommonFields = sourceEnrichmentFields.CommonFields
 	row.TpID = xid.New().String()
 	row.TpTimestamp = row.Timestamp
 	row.TpIngestTimestamp = time.Now()


### PR DESCRIPTION
- Source now passes SourceEnrichment struct to the Enrich function instead of just CommonFields
- Table.SupportedSources renamed to GetSourceMetadata
- MapperFunc is now just Mapper and should be populated with a mapper instance
- Pointless Mapper constructors removed
- EnrichRow now also takes a config param
- DelimitedLineMapper renamed to RowPatternMapper
